### PR TITLE
Eta cut windows

### DIFF
--- a/L1Trigger/L1TGlobal/interface/CaloTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/CaloTemplate.h
@@ -15,8 +15,8 @@
 
  * \new features: R. Cavanaugh
  *          - added LUT bit for LLP displaced jets
- *            Note: Calo Trig considers the DISP bit part of the 
- *                  quality word, but uGT firmware considers the 
+ *            Note: Calo Trig considers the DISP bit part of the
+ *                  quality word, but uGT firmware considers the
  *                  DISP bit to be distinct from the quality word.
  *
  * $Date$
@@ -57,6 +57,11 @@ public:
   CaloTemplate& operator=(const CaloTemplate&);
 
 public:
+  struct Window {
+    unsigned int lower;
+    unsigned int upper;
+  };
+
   /// typedef for a single object template
   struct ObjectParameter {
     unsigned int etLowThreshold;
@@ -70,10 +75,7 @@ public:
     unsigned int qualityLUT;
     unsigned int displacedLUT;  // Added for LLP Jets
 
-    unsigned int etaWindow1Lower;
-    unsigned int etaWindow1Upper;
-    unsigned int etaWindow2Lower;
-    unsigned int etaWindow2Upper;
+    std::vector<Window> etaWindows;
 
     unsigned int phiWindow1Lower;
     unsigned int phiWindow1Upper;

--- a/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
@@ -142,6 +142,11 @@ namespace l1t {
                                   const Type1& lowerR,
                                   const Type1& upperR) const;
 
+    /// check if a value is in a given range
+    template <class Type1>
+    const bool checkRangeTfMuonIndex(const unsigned int bitNumber,
+                                     const std::vector<Type1>& windows) const;
+
   protected:
     /// maximum number of objects received for the evaluation of the condition
     /// usually retrieved from event setup
@@ -502,6 +507,22 @@ namespace l1t {
     else {
       return false;
     }
+  }
+
+  template <class Type1>
+  const bool ConditionEvaluation::checkRangeTfMuonIndex(const unsigned int value,
+                                                        const std::vector<Type1>& windows) const {
+    if (windows.empty()) {
+      return true;
+    }
+
+    for (const auto& window : windows) {
+      if ((window.lower <= value) and (value <= window.upper)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
 }  // namespace l1t

--- a/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
@@ -113,10 +113,7 @@ namespace l1t {
     /// check if a value is in a given range and outside of a veto range
     template <class Type1>
     const bool checkRangeEta(const unsigned int bitNumber,
-                             const Type1& W1beginR,
-                             const Type1& W1endR,
-                             const Type1& W2beginR,
-                             const Type1& W2endR,
+                             const std::vector<Type1>& windows,
                              const unsigned int nEtaBits) const;
 
     /// check if a value is in a given range and outside of a veto range
@@ -282,76 +279,45 @@ namespace l1t {
   /// check if a value is in a given range and outside of a veto range
   template <class Type1>
   const bool ConditionEvaluation::checkRangeEta(const unsigned int bitNumber,
-                                                const Type1& W1beginR,
-                                                const Type1& W1endR,
-                                                const Type1& W2beginR,
-                                                const Type1& W2endR,
+                                                const std::vector<Type1>& windows,
                                                 const unsigned int nEtaBits) const {
-    // set condtion to true if beginR==endR = default -1
-    if (W1beginR == W1endR && W1beginR == (Type1)-1) {
+    if (windows.empty()) {
       return true;
     }
 
-    unsigned int W1diff1 = W1endR - W1beginR;
-    unsigned int W1diff2 = bitNumber - W1beginR;
-    unsigned int W1diff3 = W1endR - bitNumber;
+    for (const auto& window : windows) {
+      const unsigned int diff1 = window.upper - window.lower;
+      const unsigned int diff2 = bitNumber - window.lower;
+      const unsigned int diff3 = window.upper - bitNumber;
 
-    bool W1cond1 = ((W1diff1 >> nEtaBits) & 1) ? false : true;
-    bool W1cond2 = ((W1diff2 >> nEtaBits) & 1) ? false : true;
-    bool W1cond3 = ((W1diff3 >> nEtaBits) & 1) ? false : true;
+      const bool cond1 = ((diff1 >> nEtaBits) & 1) ? false : true;
+      const bool cond2 = ((diff2 >> nEtaBits) & 1) ? false : true;
+      const bool cond3 = ((diff3 >> nEtaBits) & 1) ? false : true;
 
-    // check if value is in range
-    // for begin <= end takes [begin, end]
-    // for begin >= end takes [begin, end] over zero angle!
-    bool passWindow1 = false;
-    if (W1cond1 && (W1cond2 && W1cond3))
-      passWindow1 = true;
-    else if (!W1cond1 && (W1cond2 || W1cond3))
-      passWindow1 = true;
-    else {
-      passWindow1 = false;
+      // check if value is in range
+      // for begin <= end takes [begin, end]
+      // for begin >= end takes [begin, end] over zero angle!
+      bool passWindow = false;
+      if (cond1 && (cond2 && cond3))
+        passWindow = true;
+      else if (!cond1 && (cond2 || cond3))
+        passWindow = true;
+
+      LogDebug("l1t|Global") << "\n l1t::ConditionEvaluation"
+                             << "\n\t bitNumber = " << bitNumber
+                             << "\n\t window.lower = " << window.lower
+                             << "\n\t window.upper = " << window.upper
+                             << "\n\t diff1 = " << diff1
+                             << "\n\t cond1 = " << cond1 << "\n\t diff2 = " << diff2
+                             << "\n\t cond2 = " << cond2 << "\n\t diff3 = " << diff3
+                             << "\n\t cond3 = " << cond3 << "\n\t passWindow = " << passWindow << std::endl;
+
+      if (passWindow) {
+        return true;
+      }
     }
 
-    LogDebug("l1t|Global") << "\n l1t::ConditionEvaluation"
-                           << "\n\t bitNumber = " << bitNumber << "\n\t W1beginR = " << W1beginR
-                           << "\n\t W1endR   = " << W1endR << "\n\t W1diff1 = " << W1diff1
-                           << "\n\t W1cond1 = " << W1cond1 << "\n\t W1diff2 = " << W1diff2
-                           << "\n\t W1cond2 = " << W1cond2 << "\n\t W1diff3 = " << W1diff3
-                           << "\n\t W1cond3 = " << W1cond3 << "\n\t passWindow1 = " << passWindow1 << std::endl;
-
-    if (W2beginR == W2endR && W2beginR == (Type1)-1) {
-      return passWindow1;
-    }
-
-    unsigned int W2diff1 = W2endR - W2beginR;
-    unsigned int W2diff2 = bitNumber - W2beginR;
-    unsigned int W2diff3 = W2endR - bitNumber;
-
-    bool W2cond1 = ((W2diff1 >> nEtaBits) & 1) ? false : true;
-    bool W2cond2 = ((W2diff2 >> nEtaBits) & 1) ? false : true;
-    bool W2cond3 = ((W2diff3 >> nEtaBits) & 1) ? false : true;
-
-    bool passWindow2 = false;
-    if (W2cond1 && (W2cond2 && W2cond3))
-      passWindow2 = true;
-    else if (!W2cond1 && (W2cond2 || W2cond3))
-      passWindow2 = true;
-    else {
-      passWindow2 = false;
-    }
-
-    LogDebug("l1t|Global") << "\n\t W2beginR = " << W2beginR << "\n\t W2endR   = " << W2endR
-                           << "\n\t W2diff1 = " << W2diff1 << "\n\t W2cond1 = " << W2cond1
-                           << "\n\t W2diff2 = " << W2diff2 << "\n\t W2cond2 = " << W2cond2
-                           << "\n\t W2diff3 = " << W2diff3 << "\n\t W2cond3 = " << W2cond3
-                           << "\n\t passWindow2 = " << passWindow2
-                           << "\n\t pass W1 || W2 = " << (passWindow1 || passWindow2) << std::endl;
-
-    if (passWindow1 || passWindow2) {
-      return true;
-    } else {
-      return false;
-    }
+    return false;
   }
 
   /// check if a value is in a given range and outside of a veto range

--- a/L1Trigger/L1TGlobal/interface/MuonTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/MuonTemplate.h
@@ -51,6 +51,11 @@ public:
   MuonTemplate& operator=(const MuonTemplate&);
 
 public:
+  struct Window {
+    unsigned int lower;
+    unsigned int upper;
+  };
+
   // typedef for a single object template
   struct ObjectParameter {
     unsigned int unconstrainedPtHigh;
@@ -82,6 +87,8 @@ public:
     unsigned int phiWindow1Upper;
     unsigned int phiWindow2Lower;
     unsigned int phiWindow2Upper;
+
+    std::vector<Window> tfMuonIndexWindows;
   };
 
   // typedef for correlation parameters

--- a/L1Trigger/L1TGlobal/interface/MuonTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/MuonTemplate.h
@@ -78,10 +78,7 @@ public:
 
     int charge;
 
-    unsigned int etaWindow1Lower;
-    unsigned int etaWindow1Upper;
-    unsigned int etaWindow2Lower;
-    unsigned int etaWindow2Upper;
+    std::vector<Window> etaWindows;
 
     unsigned int phiWindow1Lower;
     unsigned int phiWindow1Upper;

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -1146,6 +1146,8 @@ bool l1t::TriggerMenuParser::parseMuon(L1TUtmCondition condMu, unsigned int chip
     int charge = -1;               //default value is to ignore unless specified
     int qualityLUT = 0xFFFF;       //default is to ignore unless specified.
 
+    std::vector<MuonTemplate::Window> tfMuonIndexWindows;
+
     const std::vector<L1TUtmCut>& cuts = object.getCuts();
     for (size_t kk = 0; kk < cuts.size(); kk++) {
       const L1TUtmCut& cut = cuts.at(kk);
@@ -1221,6 +1223,14 @@ bool l1t::TriggerMenuParser::parseMuon(L1TUtmCondition condMu, unsigned int chip
           isolationLUT = l1tstr2int(cut.getData());
 
         } break;
+
+        case esCutType::Index: {
+          tfMuonIndexWindows.push_back({
+            cut.getMinimum().index,
+            cut.getMaximum().index
+          });
+        } break;
+
         default:
           break;
       }  //end switch
@@ -1258,6 +1268,8 @@ bool l1t::TriggerMenuParser::parseMuon(L1TUtmCondition condMu, unsigned int chip
     objParameter[cnt].charge = charge;
     objParameter[cnt].qualityLUT = qualityLUT;
     objParameter[cnt].isolationLUT = isolationLUT;
+
+    objParameter[cnt].tfMuonIndexWindows = tfMuonIndexWindows;
 
     cnt++;
   }  //end loop over objects
@@ -1378,6 +1390,8 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const L1TUtmObject* corrMu, unsigned 
   int charge = -1;          //defaut is to ignore unless specified
   int qualityLUT = 0xFFFF;  //default is to ignore unless specified.
 
+  std::vector<MuonTemplate::Window> tfMuonIndexWindows;
+
   const std::vector<L1TUtmCut>& cuts = corrMu->getCuts();
   for (size_t kk = 0; kk < cuts.size(); kk++) {
     const L1TUtmCut& cut = cuts.at(kk);
@@ -1453,6 +1467,14 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const L1TUtmObject* corrMu, unsigned 
         isolationLUT = l1tstr2int(cut.getData());
 
       } break;
+
+      case esCutType::Index: {
+        tfMuonIndexWindows.push_back({
+          cut.getMinimum().index,
+          cut.getMaximum().index
+        });
+      } break;
+
       default:
         break;
     }  //end switch
@@ -1490,6 +1512,8 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const L1TUtmObject* corrMu, unsigned 
   objParameter[0].charge = charge;
   objParameter[0].qualityLUT = qualityLUT;
   objParameter[0].isolationLUT = isolationLUT;
+
+  objParameter[0].tfMuonIndexWindows = tfMuonIndexWindows;
 
   // object types - all muons
   std::vector<GlobalObject> objType(nrObj, gtMu);

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -1137,8 +1137,6 @@ bool l1t::TriggerMenuParser::parseMuon(L1TUtmCondition condMu, unsigned int chip
     int lowerThresholdInd = 0;
     int upperIndexInd = -1;
     int lowerIndexInd = 0;
-    int cntEta = 0;
-    unsigned int etaWindow1Lower = -1, etaWindow1Upper = -1, etaWindow2Lower = -1, etaWindow2Upper = -1;
     int cntPhi = 0;
     unsigned int phiWindow1Lower = -1, phiWindow1Upper = -1, phiWindow2Lower = -1, phiWindow2Upper = -1;
     int isolationLUT = 0xF;        //default is to ignore unless specified.
@@ -1146,6 +1144,7 @@ bool l1t::TriggerMenuParser::parseMuon(L1TUtmCondition condMu, unsigned int chip
     int charge = -1;               //default value is to ignore unless specified
     int qualityLUT = 0xFFFF;       //default is to ignore unless specified.
 
+    std::vector<MuonTemplate::Window> etaWindows;
     std::vector<MuonTemplate::Window> tfMuonIndexWindows;
 
     const std::vector<L1TUtmCut>& cuts = object.getCuts();
@@ -1175,19 +1174,16 @@ bool l1t::TriggerMenuParser::parseMuon(L1TUtmCondition condMu, unsigned int chip
           break;
 
         case esCutType::Eta: {
-          if (cntEta == 0) {
-            etaWindow1Lower = cut.getMinimum().index;
-            etaWindow1Upper = cut.getMaximum().index;
-          } else if (cntEta == 1) {
-            etaWindow2Lower = cut.getMinimum().index;
-            etaWindow2Upper = cut.getMaximum().index;
+          if (etaWindows.size() < 5) {
+            tfMuonIndexWindows.push_back({
+              cut.getMinimum().index,
+              cut.getMaximum().index
+            });
           } else {
             edm::LogError("TriggerMenuParser")
                 << "Too Many Eta Cuts for muon-condition (" << particle << ")" << std::endl;
             return false;
           }
-          cntEta++;
-
         } break;
 
         case esCutType::Phi: {
@@ -1250,10 +1246,7 @@ bool l1t::TriggerMenuParser::parseMuon(L1TUtmCondition condMu, unsigned int chip
     objParameter[cnt].indexHigh = upperIndexInd;
     objParameter[cnt].indexLow = lowerIndexInd;
 
-    objParameter[cnt].etaWindow1Lower = etaWindow1Lower;
-    objParameter[cnt].etaWindow1Upper = etaWindow1Upper;
-    objParameter[cnt].etaWindow2Lower = etaWindow2Lower;
-    objParameter[cnt].etaWindow2Upper = etaWindow2Upper;
+    objParameter[cnt].etaWindows = etaWindows;
 
     objParameter[cnt].phiWindow1Lower = phiWindow1Lower;
     objParameter[cnt].phiWindow1Upper = phiWindow1Upper;
@@ -1382,14 +1375,13 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const L1TUtmObject* corrMu, unsigned 
   int lowerThresholdInd = 0;
   int upperIndexInd = -1;
   int lowerIndexInd = 0;
-  int cntEta = 0;
-  unsigned int etaWindow1Lower = -1, etaWindow1Upper = -1, etaWindow2Lower = -1, etaWindow2Upper = -1;
   int cntPhi = 0;
   unsigned int phiWindow1Lower = -1, phiWindow1Upper = -1, phiWindow2Lower = -1, phiWindow2Upper = -1;
   int isolationLUT = 0xF;   //default is to ignore unless specified.
   int charge = -1;          //defaut is to ignore unless specified
   int qualityLUT = 0xFFFF;  //default is to ignore unless specified.
 
+  std::vector<MuonTemplate::Window> etaWindows;
   std::vector<MuonTemplate::Window> tfMuonIndexWindows;
 
   const std::vector<L1TUtmCut>& cuts = corrMu->getCuts();
@@ -1419,19 +1411,16 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const L1TUtmObject* corrMu, unsigned 
         break;
 
       case esCutType::Eta: {
-        if (cntEta == 0) {
-          etaWindow1Lower = cut.getMinimum().index;
-          etaWindow1Upper = cut.getMaximum().index;
-        } else if (cntEta == 1) {
-          etaWindow2Lower = cut.getMinimum().index;
-          etaWindow2Upper = cut.getMaximum().index;
+        if (etaWindows.size() < 5) {
+          etaWindows.push_back({
+            cut.getMinimum().index,
+            cut.getMaximum().index
+          });
         } else {
           edm::LogError("TriggerMenuParser")
               << "Too Many Eta Cuts for muon-condition (" << particle << ")" << std::endl;
           return false;
         }
-        cntEta++;
-
       } break;
 
       case esCutType::Phi: {
@@ -1494,10 +1483,7 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const L1TUtmObject* corrMu, unsigned 
   objParameter[0].indexHigh = upperIndexInd;
   objParameter[0].indexLow = lowerIndexInd;
 
-  objParameter[0].etaWindow1Lower = etaWindow1Lower;
-  objParameter[0].etaWindow1Upper = etaWindow1Upper;
-  objParameter[0].etaWindow2Lower = etaWindow2Lower;
-  objParameter[0].etaWindow2Upper = etaWindow2Upper;
+  objParameter[0].etaWindows = etaWindows;
 
   objParameter[0].phiWindow1Lower = phiWindow1Lower;
   objParameter[0].phiWindow1Upper = phiWindow1Upper;
@@ -1778,8 +1764,6 @@ bool l1t::TriggerMenuParser::parseCalo(L1TUtmCondition condCalo, unsigned int ch
     int lowerThresholdInd = 0;
     int upperIndexInd = -1;
     int lowerIndexInd = 0;
-    int cntEta = 0;
-    unsigned int etaWindow1Lower = -1, etaWindow1Upper = -1, etaWindow2Lower = -1, etaWindow2Upper = -1;
     int cntPhi = 0;
     unsigned int phiWindow1Lower = -1, phiWindow1Upper = -1, phiWindow2Lower = -1, phiWindow2Upper = -1;
     int isolationLUT = 0xF;  //default is to ignore isolation unless specified.
@@ -1787,6 +1771,8 @@ bool l1t::TriggerMenuParser::parseCalo(L1TUtmCondition condCalo, unsigned int ch
     int displacedLUT = 0x0;  // Added for LLP Jets: single bit LUT: { 0 = noLLP default, 1 = LLP }
                              // Note: Currently assumes that the LSB from hwQual() getter in L1Candidate provides the
                              // (single bit) information for the displacedLUT
+
+    std::vector<CaloTemplate::Window> etaWindows;
 
     const std::vector<L1TUtmCut>& cuts = object.getCuts();
     for (size_t kk = 0; kk < cuts.size(); kk++) {
@@ -1802,19 +1788,16 @@ bool l1t::TriggerMenuParser::parseCalo(L1TUtmCondition condCalo, unsigned int ch
           upperIndexInd = int(cut.getMaximum().value);
           break;
         case esCutType::Eta: {
-          if (cntEta == 0) {
-            etaWindow1Lower = cut.getMinimum().index;
-            etaWindow1Upper = cut.getMaximum().index;
-          } else if (cntEta == 1) {
-            etaWindow2Lower = cut.getMinimum().index;
-            etaWindow2Upper = cut.getMaximum().index;
+          if (etaWindows.size() < 5) {
+            etaWindows.push_back({
+              cut.getMinimum().index,
+              cut.getMaximum().index
+            });
           } else {
             edm::LogError("TriggerMenuParser")
                 << "Too Many Eta Cuts for calo-condition (" << particle << ")" << std::endl;
             return false;
           }
-          cntEta++;
-
         } break;
 
         case esCutType::Phi: {
@@ -1861,10 +1844,7 @@ bool l1t::TriggerMenuParser::parseCalo(L1TUtmCondition condCalo, unsigned int ch
     objParameter[cnt].etLowThreshold = lowerThresholdInd;
     objParameter[cnt].indexHigh = upperIndexInd;
     objParameter[cnt].indexLow = lowerIndexInd;
-    objParameter[cnt].etaWindow1Lower = etaWindow1Lower;
-    objParameter[cnt].etaWindow1Upper = etaWindow1Upper;
-    objParameter[cnt].etaWindow2Lower = etaWindow2Lower;
-    objParameter[cnt].etaWindow2Upper = etaWindow2Upper;
+    objParameter[cnt].etaWindows = etaWindows;
     objParameter[cnt].phiWindow1Lower = phiWindow1Lower;
     objParameter[cnt].phiWindow1Upper = phiWindow1Upper;
     objParameter[cnt].phiWindow2Lower = phiWindow2Lower;
@@ -1874,21 +1854,24 @@ bool l1t::TriggerMenuParser::parseCalo(L1TUtmCondition condCalo, unsigned int ch
     objParameter[cnt].displacedLUT = displacedLUT;  // Added for LLP Jets
 
     // Output for debugging
-    LogDebug("TriggerMenuParser") << "\n      Calo ET high thresholds (hex) for calo object " << caloObjType << " "
-                                  << cnt << " = " << std::hex << objParameter[cnt].etLowThreshold << " - "
-                                  << objParameter[cnt].etHighThreshold
-                                  << "\n      etaWindow Lower / Upper for calo object " << cnt << " = 0x"
-                                  << objParameter[cnt].etaWindow1Lower << " / 0x" << objParameter[cnt].etaWindow1Upper
-                                  << "\n      etaWindowVeto Lower / Upper for calo object " << cnt << " = 0x"
-                                  << objParameter[cnt].etaWindow2Lower << " / 0x" << objParameter[cnt].etaWindow2Upper
-                                  << "\n      phiWindow Lower / Upper for calo object " << cnt << " = 0x"
-                                  << objParameter[cnt].phiWindow1Lower << " / 0x" << objParameter[cnt].phiWindow1Upper
-                                  << "\n      phiWindowVeto Lower / Upper for calo object " << cnt << " = 0x"
-                                  << objParameter[cnt].phiWindow2Lower << " / 0x" << objParameter[cnt].phiWindow2Upper
-                                  << "\n      Isolation LUT for calo object " << cnt << " = 0x"
-                                  << objParameter[cnt].isolationLUT << "\n      Quality LUT for calo object " << cnt
-                                  << " = 0x" << objParameter[cnt].qualityLUT << "\n      LLP DISP LUT for calo object "
-                                  << cnt << " = 0x" << objParameter[cnt].displacedLUT << std::dec << std::endl;
+    {
+      std::ostringstream oss;
+      oss << "\n      Calo ET high thresholds (hex) for calo object " << caloObjType << " "
+          << cnt << " = " << std::hex << objParameter[cnt].etLowThreshold << " - "
+          << objParameter[cnt].etHighThreshold;
+      for (const atuo& window : objParameter[cnt].etaWindows) {
+        oss << "\n      etaWindow Lower / Upper for calo object " << cnt << " = 0x" << window.lower << " / 0x" << window.upper;
+      }
+      oss << "\n      phiWindow Lower / Upper for calo object " << cnt << " = 0x"
+          << objParameter[cnt].phiWindow1Lower << " / 0x" << objParameter[cnt].phiWindow1Upper
+          << "\n      phiWindowVeto Lower / Upper for calo object " << cnt << " = 0x"
+          << objParameter[cnt].phiWindow2Lower << " / 0x" << objParameter[cnt].phiWindow2Upper
+          << "\n      Isolation LUT for calo object " << cnt << " = 0x"
+          << objParameter[cnt].isolationLUT << "\n      Quality LUT for calo object " << cnt
+          << " = 0x" << objParameter[cnt].qualityLUT << "\n      LLP DISP LUT for calo object "
+          << cnt << " = 0x" << objParameter[cnt].displacedLUT;
+      LogDebug("TriggerMenuParser") oss.str() << std::endl;
+    }
 
     cnt++;
   }  //end loop over objects
@@ -2013,8 +1996,6 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const L1TUtmObject* corrCalo, unsigne
   int lowerThresholdInd = 0;
   int upperIndexInd = -1;
   int lowerIndexInd = 0;
-  int cntEta = 0;
-  unsigned int etaWindow1Lower = -1, etaWindow1Upper = -1, etaWindow2Lower = -1, etaWindow2Upper = -1;
   int cntPhi = 0;
   unsigned int phiWindow1Lower = -1, phiWindow1Upper = -1, phiWindow2Lower = -1, phiWindow2Upper = -1;
   int isolationLUT = 0xF;  //default is to ignore isolation unless specified.
@@ -2022,6 +2003,8 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const L1TUtmObject* corrCalo, unsigne
   int displacedLUT = 0x0;  // Added for LLP Jets:  single bit LUT:  { 0 = noLLP default, 1 = LLP }
                            // Note:  Currently assume that the hwQual() getter in L1Candidate provides the
                            //        (single bit) information for the displacedLUT
+
+  std::vector<CaloTemplate::Window> etaWindows;
 
   const std::vector<L1TUtmCut>& cuts = corrCalo->getCuts();
   for (size_t kk = 0; kk < cuts.size(); kk++) {
@@ -2037,19 +2020,16 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const L1TUtmObject* corrCalo, unsigne
         upperIndexInd = int(cut.getMaximum().value);
         break;
       case esCutType::Eta: {
-        if (cntEta == 0) {
-          etaWindow1Lower = cut.getMinimum().index;
-          etaWindow1Upper = cut.getMaximum().index;
-        } else if (cntEta == 1) {
-          etaWindow2Lower = cut.getMinimum().index;
-          etaWindow2Upper = cut.getMaximum().index;
+        if (etaWindows.size() < 5) {
+          etaWindows.push_back({
+            cut.getMinimum().index,
+            cut.getMaximum().index
+          });
         } else {
           edm::LogError("TriggerMenuParser")
               << "Too Many Eta Cuts for calo-condition (" << particle << ")" << std::endl;
           return false;
         }
-        cntEta++;
-
       } break;
 
       case esCutType::Phi: {
@@ -2096,10 +2076,7 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const L1TUtmObject* corrCalo, unsigne
   objParameter[0].etHighThreshold = upperThresholdInd;
   objParameter[0].indexHigh = upperIndexInd;
   objParameter[0].indexLow = lowerIndexInd;
-  objParameter[0].etaWindow1Lower = etaWindow1Lower;
-  objParameter[0].etaWindow1Upper = etaWindow1Upper;
-  objParameter[0].etaWindow2Lower = etaWindow2Lower;
-  objParameter[0].etaWindow2Upper = etaWindow2Upper;
+  objParameter[0].etaWindows = etaWindows;
   objParameter[0].phiWindow1Lower = phiWindow1Lower;
   objParameter[0].phiWindow1Upper = phiWindow1Upper;
   objParameter[0].phiWindow2Lower = phiWindow2Lower;
@@ -2109,22 +2086,24 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const L1TUtmObject* corrCalo, unsigne
   objParameter[0].displacedLUT = displacedLUT;  // Added for LLP Jets
 
   // Output for debugging
-  LogDebug("TriggerMenuParser") << "\n      Calo ET high threshold (hex) for calo object " << caloObjType << " "
-                                << " = " << std::hex << objParameter[0].etLowThreshold << " - "
-                                << objParameter[0].etHighThreshold << "\n      etaWindow Lower / Upper for calo object "
-                                << " = 0x" << objParameter[0].etaWindow1Lower << " / 0x"
-                                << objParameter[0].etaWindow1Upper
-                                << "\n      etaWindowVeto Lower / Upper for calo object "
-                                << " = 0x" << objParameter[0].etaWindow2Lower << " / 0x"
-                                << objParameter[0].etaWindow2Upper << "\n      phiWindow Lower / Upper for calo object "
-                                << " = 0x" << objParameter[0].phiWindow1Lower << " / 0x"
-                                << objParameter[0].phiWindow1Upper
-                                << "\n      phiWindowVeto Lower / Upper for calo object "
-                                << " = 0x" << objParameter[0].phiWindow2Lower << " / 0x"
-                                << objParameter[0].phiWindow2Upper << "\n      Isolation LUT for calo object "
-                                << " = 0x" << objParameter[0].isolationLUT << "\n      Quality LUT for calo object "
-                                << " = 0x" << objParameter[0].qualityLUT << "\n      LLP DISP LUT for calo object "
-                                << " = 0x" << objParameter[0].displacedLUT << std::dec << std::endl;
+  {
+    std::ostringstream oss;
+    oss << "\n      Calo ET high threshold (hex) for calo object " << caloObjType << " "
+        << " = " << std::hex << objParameter[0].etLowThreshold << " - " << objParameter[0].etHighThreshold;
+    for (const auto& window : objParameter[0].etaWindows) {
+      oss << "\n      etaWindow Lower / Upper for calo object " << " = 0x" << window.lower << " / 0x" << window.upper;
+    }
+    oss << "\n      phiWindow Lower / Upper for calo object "
+        << " = 0x" << objParameter[0].phiWindow1Lower << " / 0x"
+        << objParameter[0].phiWindow1Upper
+        << "\n      phiWindowVeto Lower / Upper for calo object "
+        << " = 0x" << objParameter[0].phiWindow2Lower << " / 0x"
+        << objParameter[0].phiWindow2Upper << "\n      Isolation LUT for calo object "
+        << " = 0x" << objParameter[0].isolationLUT << "\n      Quality LUT for calo object "
+        << " = 0x" << objParameter[0].qualityLUT << "\n      LLP DISP LUT for calo object "
+        << " = 0x" << objParameter[0].displacedLUT;
+    LogDebug("TriggerMenuParser") << oss.str() << std::endl;
+  }
 
   // object types - all same caloObjType
   std::vector<GlobalObject> objType(nrObj, caloObjType);

--- a/L1Trigger/L1TGlobal/src/CaloCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CaloCondition.cc
@@ -490,12 +490,7 @@ const bool l1t::CaloCondition::checkObjectParameter(const int iCondition,
   }
 
   // check eta
-  if (!checkRangeEta(cand.hwEta(),
-                     objPar.etaWindow1Lower,
-                     objPar.etaWindow1Upper,
-                     objPar.etaWindow2Lower,
-                     objPar.etaWindow2Upper,
-                     7)) {
+  if (!checkRangeEta(cand.hwEta(), objPar.etaWindows, 7)) {
     LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed checkRange(eta)" << std::endl;
     return false;
   }

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -487,6 +487,12 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
     return false;
   }
 
+  // check muon TF index
+  if (!checkRangeTfMuonIndex(cand.tfMuonIndex(), objPar.tfMuonIndexWindows)) {
+    LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed checkRange(tfMuonIndex)" << std::endl;
+    return false;
+  }
+
   // A number of values is required to trigger (at least one).
   // "Don't care" means that all values are allowed.
   // Qual = 000 means then NO MUON (GTL module)

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -435,12 +435,7 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
   }
 
   // check eta
-  if (!checkRangeEta(cand.hwEtaAtVtx(),
-                     objPar.etaWindow1Lower,
-                     objPar.etaWindow1Upper,
-                     objPar.etaWindow2Lower,
-                     objPar.etaWindow2Upper,
-                     8)) {
+  if (!checkRangeEta(cand.hwEtaAtVtx(), objPar.etaWindows, 8)) {
     LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed checkRange(eta)" << std::endl;
     return false;
   }

--- a/L1Trigger/L1TGlobal/src/MuonTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/MuonTemplate.cc
@@ -101,10 +101,13 @@ void MuonTemplate::print(std::ostream& myCout) const {
     myCout << "    phiWindow1Upper   =" << std::hex << m_objectParameter[i].phiWindow1Upper << std::endl;
     myCout << "    phiWindow2Lower   =" << std::hex << m_objectParameter[i].phiWindow2Lower << std::endl;
     myCout << "    phiWindow2Upper   =" << std::hex << m_objectParameter[i].phiWindow2Upper << std::endl;
-    myCout << "    etaWindow1Lower   =" << std::hex << m_objectParameter[i].etaWindow1Lower << std::endl;
-    myCout << "    etaWindow1Upper   =" << std::hex << m_objectParameter[i].etaWindow1Upper << std::endl;
-    myCout << "    etaWindow2Lower   =" << std::hex << m_objectParameter[i].etaWindow2Lower << std::endl;
-    myCout << "    etaWindow2Upper   =" << std::hex << m_objectParameter[i].etaWindow2Upper << std::endl;
+
+    size_t etaWindowIndex = 1;
+    for (const auto& window : m_objectParameter[i].etaWindows) {
+      myCout << "    etaWindows[" << etaWindowIndex << "].lower =" << std::hex << window.lower << std::endl;
+      myCout << "    etaWindows[" << etaWindowIndex << "].upper =" << std::hex << window.upper << std::endl;
+      ++etaWindowIndex;
+    }
   }
 
   if (wsc()) {


### PR DESCRIPTION
#### PR description:
This PR includes the new track finder index feature for muons in the uGT emulator, recently added to the utm library v0.11.2 (see details in [CMSLITDPG-1104](https://its.cern.ch/jira/browse/CMSLITDPG-1104)) and needed for the update of the 2023 L1 menu as detailed in [CMSLITDPG-1075](https://its.cern.ch/jira/browse/CMSLITDPG-1075)).
Moreover, it propagates the possibility to add up to five eta cuts in the design of muon and calo algorithms (present in the TME but not in the emulator).
Thanks @arnobaer for this work!