### PR TITLE
Muon index cut

### DIFF
--- a/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
@@ -142,6 +142,11 @@ namespace l1t {
                                   const Type1& lowerR,
                                   const Type1& upperR) const;
 
+    /// check if a value is in a given range
+    template <class Type1>
+    const bool checkRangeTfMuonIndex(const unsigned int bitNumber,
+                                     const std::vector<Type1>& windows) const;
+
   protected:
     /// maximum number of objects received for the evaluation of the condition
     /// usually retrieved from event setup
@@ -502,6 +507,22 @@ namespace l1t {
     else {
       return false;
     }
+  }
+
+  template <class Type1>
+  const bool ConditionEvaluation::checkRangeTfMuonIndex(const unsigned int value,
+                                                        const std::vector<Type1>& windows) const {
+    if (windows.empty()) {
+      return true;
+    }
+
+    for (const auto& window : windows) {
+      if ((window.lower <= value) and (value <= window.upper)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
 }  // namespace l1t

--- a/L1Trigger/L1TGlobal/interface/MuonTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/MuonTemplate.h
@@ -51,6 +51,11 @@ public:
   MuonTemplate& operator=(const MuonTemplate&);
 
 public:
+  struct Window {
+    unsigned int lower;
+    unsigned int upper;
+  };
+
   // typedef for a single object template
   struct ObjectParameter {
     unsigned int unconstrainedPtHigh;
@@ -82,6 +87,8 @@ public:
     unsigned int phiWindow1Upper;
     unsigned int phiWindow2Lower;
     unsigned int phiWindow2Upper;
+
+    std::vector<Window> tfMuonIndexWindows;
   };
 
   // typedef for correlation parameters

--- a/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
+++ b/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
@@ -861,6 +861,7 @@ namespace l1t {
     packedVal |= ((cms_uint64_t)(mu->hwCharge() & 0x1) << 34);            // & 0x1)   <<29);
     packedVal |= ((cms_uint64_t)(mu->hwQual() & 0xf) << 19);              // & 0xf)   <<30);
     packedVal |= ((cms_uint64_t)(mu->hwIso() & 0x3) << 32);               // & 0x3)   <<34);
+    packedVal |= ((cms_uint64_t)(mu->tfMuonIndex() & 0x7f) << 36);
 
     //    if (false) {  // for debugging purposes
     //      std::cout << "----------------------" << std::endl;

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -1146,6 +1146,8 @@ bool l1t::TriggerMenuParser::parseMuon(L1TUtmCondition condMu, unsigned int chip
     int charge = -1;               //default value is to ignore unless specified
     int qualityLUT = 0xFFFF;       //default is to ignore unless specified.
 
+    std::vector<MuonTemplate::Window> tfMuonIndexWindows;
+
     const std::vector<L1TUtmCut>& cuts = object.getCuts();
     for (size_t kk = 0; kk < cuts.size(); kk++) {
       const L1TUtmCut& cut = cuts.at(kk);
@@ -1221,6 +1223,14 @@ bool l1t::TriggerMenuParser::parseMuon(L1TUtmCondition condMu, unsigned int chip
           isolationLUT = l1tstr2int(cut.getData());
 
         } break;
+
+        case esCutType::Index: {
+          tfMuonIndexWindows.push_back({
+            cut.getMinimum().index,
+            cut.getMaximum().index
+          });
+        } break;
+
         default:
           break;
       }  //end switch
@@ -1258,6 +1268,8 @@ bool l1t::TriggerMenuParser::parseMuon(L1TUtmCondition condMu, unsigned int chip
     objParameter[cnt].charge = charge;
     objParameter[cnt].qualityLUT = qualityLUT;
     objParameter[cnt].isolationLUT = isolationLUT;
+
+    objParameter[cnt].tfMuonIndexWindows = tfMuonIndexWindows;
 
     cnt++;
   }  //end loop over objects
@@ -1378,6 +1390,8 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const L1TUtmObject* corrMu, unsigned 
   int charge = -1;          //defaut is to ignore unless specified
   int qualityLUT = 0xFFFF;  //default is to ignore unless specified.
 
+  std::vector<MuonTemplate::Window> tfMuonIndexWindows;
+
   const std::vector<L1TUtmCut>& cuts = corrMu->getCuts();
   for (size_t kk = 0; kk < cuts.size(); kk++) {
     const L1TUtmCut& cut = cuts.at(kk);
@@ -1453,6 +1467,14 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const L1TUtmObject* corrMu, unsigned 
         isolationLUT = l1tstr2int(cut.getData());
 
       } break;
+
+      case esCutType::Index: {
+        tfMuonIndexWindows.push_back({
+          cut.getMinimum().index,
+          cut.getMaximum().index
+        });
+      } break;
+
       default:
         break;
     }  //end switch
@@ -1490,6 +1512,8 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const L1TUtmObject* corrMu, unsigned 
   objParameter[0].charge = charge;
   objParameter[0].qualityLUT = qualityLUT;
   objParameter[0].isolationLUT = isolationLUT;
+
+  objParameter[0].tfMuonIndexWindows = tfMuonIndexWindows;
 
   // object types - all muons
   std::vector<GlobalObject> objType(nrObj, gtMu);

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -487,6 +487,12 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
     return false;
   }
 
+  // check muon TF index
+  if (!checkRangeTfMuonIndex(cand.tfMuonIndex(), objPar.tfMuonIndexWindows)) {
+    LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed checkRange(tfMuonIndex)" << std::endl;
+    return false;
+  }
+
   // A number of values is required to trigger (at least one).
   // "Don't care" means that all values are allowed.
   // Qual = 000 means then NO MUON (GTL module)


### PR DESCRIPTION
#### PR description:
The missing muon index data is also included in the GtRecordDumper, needed to produce a test vector as input to the firmware validation. The bits assigned to muon index in the muon object are 36..42 (see Table 6 in the uGT firmware documentation - [scales_inputs_2_ugt.pdf](https://github.com/cms-l1-globaltrigger/mp7_ugt_legacy/blob/master/doc/scales_inputs_2_ugt/pdf/scales_inputs_2_ugt.pdf)).

Thanks @arnobaer and Herbert for this work!